### PR TITLE
Add Python script to insert sign images into PDF documents, with Windows EXE build

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,0 +1,44 @@
+name: Build Windows EXE
+
+on:
+  push:
+    branches:
+      - issue-16-28ad930a2e05
+    paths:
+      - 'own/macro/pdf_sign_inserter.py'
+      - 'own/macro/pdf_sign_inserter.spec'
+      - '.github/workflows/build-exe.yml'
+  workflow_dispatch:
+
+jobs:
+  build-windows-exe:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install pymupdf pyinstaller
+
+      - name: Build EXE with PyInstaller
+        working-directory: own/macro
+        run: |
+          pyinstaller pdf_sign_inserter.spec
+
+      - name: Upload EXE artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pdf_sign_inserter-windows-exe
+          path: own/macro/dist/pdf_sign_inserter.exe
+          if-no-files-found: error
+
+      - name: Copy EXE to release folder
+        run: |
+          mkdir -p own/macro/dist
+          cp own/macro/dist/pdf_sign_inserter.exe own/macro/pdf_sign_inserter.exe
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+*.pyo

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 __pycache__/
 *.py[cod]
 *.pyo
+
+# PyInstaller build artifacts
+own/macro/build/
+own/macro/dist/

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-02T00:00:42.590Z for PR creation at branch issue-16-28ad930a2e05 for issue https://github.com/Surrogate-TM/surrogate-tm.github.io/issues/16

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-02T00:00:42.590Z for PR creation at branch issue-16-28ad930a2e05 for issue https://github.com/Surrogate-TM/surrogate-tm.github.io/issues/16

--- a/own/macro/build_exe.bat
+++ b/own/macro/build_exe.bat
@@ -1,0 +1,19 @@
+@echo off
+REM Build pdf_sign_inserter.exe from pdf_sign_inserter.py
+REM Requirements: Python 3.8+ with pip
+
+echo Installing required Python packages...
+pip install pymupdf pyinstaller
+
+echo.
+echo Building EXE...
+pyinstaller pdf_sign_inserter.spec
+
+echo.
+if exist dist\pdf_sign_inserter.exe (
+    echo SUCCESS: dist\pdf_sign_inserter.exe was created.
+    echo Copy pdf_sign_inserter.exe from the dist\ folder to use it.
+) else (
+    echo ERROR: Build failed. Check the output above for details.
+    exit /b 1
+)

--- a/own/macro/pdf_sign_inserter.py
+++ b/own/macro/pdf_sign_inserter.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+Insert signature images from PDF files in the `sign` folder into PDF documents
+from the `in` folder, and save results to the `out` folder.
+
+Folder layout (relative to this script):
+    in/   — multi-page PDF documents to receive images
+    sign/ — single-page PDF documents containing images to insert
+    out/  — output PDFs with images inserted
+
+Insertion pattern:
+    Given N sign documents, page k of an input PDF receives the image from
+    sign document number (k-1) mod N (0-indexed).
+    Example with 3 sign docs: pages 1,4,7→sign[0]; pages 2,5,8→sign[1];
+    pages 3,6,9→sign[2].
+
+Page size adjustment:
+    If a page is not an integer multiple of A4 in both dimensions, it is
+    padded/scaled to the nearest A4 multiple.
+
+Usage:
+    python3 pdf_sign_inserter.py [--in-dir IN] [--sign-dir SIGN] [--out-dir OUT]
+
+Dependencies:
+    pip install pymupdf
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    import pymupdf
+except ImportError:
+    sys.exit("Error: PyMuPDF not installed. Run: pip install pymupdf")
+
+# A4 dimensions in PDF points (72 pt = 1 inch; A4 = 210×297 mm)
+A4_WIDTH_PT = 595.28   # 210 mm
+A4_HEIGHT_PT = 841.89  # 297 mm
+
+
+def ensure_dirs(*dirs: Path) -> None:
+    """Create directories if they don't exist."""
+    for d in dirs:
+        d.mkdir(parents=True, exist_ok=True)
+
+
+def check_non_empty(folder: Path, label: str) -> None:
+    """Exit with a warning if the folder has no PDF files."""
+    pdfs = sorted(folder.glob("*.pdf"))
+    if not pdfs:
+        sys.exit(
+            f"Warning: The '{label}' folder ({folder}) contains no PDF files.\n"
+            f"Please add PDF documents to '{folder}' and run the script again."
+        )
+
+
+def nearest_a4_multiple(size_pt: float, a4_dim: float) -> float:
+    """Return the nearest integer multiple of a4_dim that is >= size_pt."""
+    import math
+    n = math.ceil(size_pt / a4_dim)
+    return max(n, 1) * a4_dim
+
+
+def is_a4_multiple(width: float, height: float, tol: float = 1.0) -> bool:
+    """Return True if width and height are already integer multiples of A4."""
+    import math
+    w_mult = width / A4_WIDTH_PT
+    h_mult = height / A4_HEIGHT_PT
+    return (
+        abs(w_mult - round(w_mult)) < tol / A4_WIDTH_PT
+        and abs(h_mult - round(h_mult)) < tol / A4_HEIGHT_PT
+    )
+
+
+def render_sign_page_as_image(sign_doc: pymupdf.Document) -> pymupdf.Pixmap:
+    """Render the first page of a sign document to a high-resolution pixmap."""
+    page = sign_doc[0]
+    mat = pymupdf.Matrix(2, 2)  # 2x zoom → 144 dpi
+    return page.get_pixmap(matrix=mat, alpha=True)
+
+
+def get_sign_rect_on_page(
+    sign_doc: pymupdf.Document,
+) -> tuple[pymupdf.Rect, pymupdf.Pixmap]:
+    """
+    Return the bounding rect of content on the first page of the sign doc,
+    and a pixmap rendering of that content.
+    """
+    page = sign_doc[0]
+    # Try to get the bbox of actual content (tighter than full page)
+    content_rect = page.rect  # fall back to full page rect
+    mat = pymupdf.Matrix(2, 2)
+    clip_mat = pymupdf.Matrix(2, 2)
+    pix = page.get_pixmap(matrix=clip_mat, alpha=True, clip=content_rect)
+    return content_rect, pix
+
+
+def adjust_page_size(page: pymupdf.Page) -> None:
+    """
+    Resize the page to the nearest integer multiple of A4 dimensions if needed.
+    Content is kept at its current position; extra space is transparent.
+    """
+    rect = page.rect
+    w, h = rect.width, rect.height
+
+    if is_a4_multiple(w, h):
+        return
+
+    new_w = nearest_a4_multiple(w, A4_WIDTH_PT)
+    new_h = nearest_a4_multiple(h, A4_HEIGHT_PT)
+
+    new_rect = pymupdf.Rect(0, 0, new_w, new_h)
+    page.set_mediabox(new_rect)
+
+
+def insert_sign_into_page(
+    out_page: pymupdf.Page,
+    sign_doc: pymupdf.Document,
+    sign_pix: pymupdf.Pixmap,
+    sign_rect: pymupdf.Rect,
+) -> None:
+    """
+    Overlay the sign image onto out_page.
+
+    The sign image is placed at the same relative position it occupies on the
+    sign PDF page (preserving its size in points).  If it doesn't fit on the
+    target page, it is scaled down proportionally.
+    """
+    page_rect = out_page.rect
+
+    sign_page = sign_doc[0]
+    sign_page_rect = sign_page.rect
+
+    # Position the sign's content rect on the target page (same offset from top-left)
+    # Scale if the sign page is larger than the target page.
+    scale_x = min(1.0, page_rect.width / sign_page_rect.width)
+    scale_y = min(1.0, page_rect.height / sign_page_rect.height)
+    scale = min(scale_x, scale_y)
+
+    dest_x0 = sign_rect.x0 * scale
+    dest_y0 = sign_rect.y0 * scale
+    dest_x1 = sign_rect.x1 * scale
+    dest_y1 = sign_rect.y1 * scale
+    dest_rect = pymupdf.Rect(dest_x0, dest_y0, dest_x1, dest_y1)
+
+    out_page.insert_image(dest_rect, pixmap=sign_pix, overlay=True)
+
+
+def process_pdf(
+    in_path: Path,
+    sign_docs: list[pymupdf.Document],
+    sign_pixmaps: list[tuple[pymupdf.Rect, pymupdf.Pixmap]],
+    out_path: Path,
+) -> None:
+    """Process a single input PDF: adjust page sizes and insert sign images."""
+    print(f"  Processing: {in_path.name}")
+    doc = pymupdf.open(str(in_path))
+    n_signs = len(sign_docs)
+
+    for page_idx in range(doc.page_count):
+        page = doc[page_idx]
+
+        # Adjust page size to A4 multiple if needed
+        adjust_page_size(page)
+
+        # Select sign document for this page (0-indexed cycling)
+        sign_idx = page_idx % n_signs
+        sign_rect, sign_pix = sign_pixmaps[sign_idx]
+
+        insert_sign_into_page(page, sign_docs[sign_idx], sign_pix, sign_rect)
+
+    doc.save(str(out_path), deflate=True)
+    doc.close()
+    print(f"    Saved: {out_path.name}")
+
+
+def main() -> None:
+    script_dir = Path(__file__).resolve().parent
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Insert signature images from PDFs in 'sign/' into PDFs in 'in/',\n"
+            "saving results to 'out/'.\n\n"
+            "Requires: pip install pymupdf"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--in-dir",
+        default=str(script_dir / "in"),
+        help="Folder with input PDFs (default: in/ next to script)",
+    )
+    parser.add_argument(
+        "--sign-dir",
+        default=str(script_dir / "sign"),
+        help="Folder with sign PDFs (default: sign/ next to script)",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=str(script_dir / "out"),
+        help="Output folder (default: out/ next to script)",
+    )
+    args = parser.parse_args()
+
+    in_dir = Path(args.in_dir)
+    sign_dir = Path(args.sign_dir)
+    out_dir = Path(args.out_dir)
+
+    # Step 1: Ensure required directories exist
+    ensure_dirs(in_dir, sign_dir, out_dir)
+
+    # Step 2 & 3: Validate that folders are not empty
+    check_non_empty(in_dir, "in")
+    check_non_empty(sign_dir, "sign")
+
+    # Load and pre-render all sign documents
+    sign_paths = sorted(sign_dir.glob("*.pdf"))
+    print(f"Found {len(sign_paths)} sign document(s): {[p.name for p in sign_paths]}")
+
+    sign_docs: list[pymupdf.Document] = []
+    sign_pixmaps: list[tuple[pymupdf.Rect, pymupdf.Pixmap]] = []
+
+    for sp in sign_paths:
+        sdoc = pymupdf.open(str(sp))
+        if sdoc.page_count == 0:
+            print(f"  Warning: sign document '{sp.name}' has no pages — skipping.")
+            continue
+        rect, pix = get_sign_rect_on_page(sdoc)
+        sign_docs.append(sdoc)
+        sign_pixmaps.append((rect, pix))
+
+    if not sign_docs:
+        sys.exit(
+            "Warning: No valid sign documents found in the 'sign' folder.\n"
+            "Please add single-page PDF documents with images to the 'sign' folder."
+        )
+
+    # Step 4–6: Process each input PDF
+    in_paths = sorted(in_dir.glob("*.pdf"))
+    print(f"\nFound {len(in_paths)} input document(s): {[p.name for p in in_paths]}")
+    print()
+
+    for in_path in in_paths:
+        out_path = out_dir / in_path.name
+        try:
+            process_pdf(in_path, sign_docs, sign_pixmaps, out_path)
+        except Exception as exc:
+            print(f"  Error processing '{in_path.name}': {exc}")
+
+    # Cleanup
+    for sdoc in sign_docs:
+        sdoc.close()
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/own/macro/pdf_sign_inserter.spec
+++ b/own/macro/pdf_sign_inserter.spec
@@ -1,0 +1,45 @@
+# -*- mode: python ; coding: utf-8 -*-
+# PyInstaller spec file for pdf_sign_inserter.py
+# Build: pyinstaller pdf_sign_inserter.spec
+
+block_cipher = None
+
+a = Analysis(
+    ['pdf_sign_inserter.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=['pymupdf'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='pdf_sign_inserter',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)


### PR DESCRIPTION
## Summary

Closes #16

Adds `own/macro/pdf_sign_inserter.py` — a Python script that inserts signature images from PDF files into multi-page PDF documents.

Also adds build tooling to convert the script to a Windows executable (`.exe`), as requested.

### How the script works

1. **Folder layout** (relative to the script): `in/`, `sign/`, `out/` — created automatically if missing.
2. **`in/`** — multi-page PDF documents to receive signature images. If empty, the script exits with a warning.
3. **`sign/`** — single-page PDF documents containing images/signatures. If empty, the script exits with a warning.
4. **Insertion pattern** — with N sign documents, page k receives sign `(k-1) mod N` (0-indexed cycling):
   - Pages 1, 4, 7, … → sign document 1
   - Pages 2, 5, 8, … → sign document 2
   - Pages 3, 6, 9, … → sign document 3
5. **Page size adjustment** — pages not already an integer multiple of A4 are padded to the nearest A4 multiple.
6. **Output** — processed PDFs saved to `out/` with the same filename.

### Building the Windows EXE

#### Option A — GitHub Actions (automatic)

The workflow `.github/workflows/build-exe.yml` runs on Windows and produces a single-file `pdf_sign_inserter.exe` as a build artifact. Download it from the **Actions** tab → latest `Build Windows EXE` run → artifact `pdf_sign_inserter-windows-exe`.

#### Option B — Build locally on Windows

```bat
cd own\macro
build_exe.bat
```

The EXE will appear in `own\macro\dist\pdf_sign_inserter.exe`.

#### Option C — Run as Python script

```bash
pip install pymupdf
python3 own/macro/pdf_sign_inserter.py [--in-dir IN] [--sign-dir SIGN] [--out-dir OUT]
```

### New files

| File | Purpose |
|---|---|
| `own/macro/pdf_sign_inserter.py` | Main Python script |
| `own/macro/pdf_sign_inserter.spec` | PyInstaller spec for EXE build |
| `own/macro/build_exe.bat` | Windows batch script to build EXE locally |
| `.github/workflows/build-exe.yml` | CI workflow: build EXE on Windows, upload artifact |

### Test plan

- [x] Script creates `in/`, `sign/`, `out/` when they don't exist
- [x] Script exits with a warning when `in/` is empty
- [x] Script exits with a warning when `sign/` is empty
- [x] 4-page input PDF with 3 sign documents → each page gets the correct sign (cycling: 1→sign1, 2→sign2, 3→sign3, 4→sign1)
- [x] Non-A4 pages (e.g. 400×600 pt) are resized to A4 (595×841 pt)
- [x] Output PDFs contain exactly one inserted image per page
- [x] PyInstaller spec builds successfully (verified on Linux; Windows build via GitHub Actions)